### PR TITLE
[feature] Reduce CPU + memory resources

### DIFF
--- a/ops/roles/reservations/tasks/app.yml
+++ b/ops/roles/reservations/tasks/app.yml
@@ -163,7 +163,7 @@
                 resources:
                   requests:
                     cpu: "150m"
-                    memory: "1Gi"
+                    memory: "512Mi"
                   limits:
                     cpu: "300m"
                     memory: "1Gi"

--- a/ops/roles/reservations/tasks/app.yml
+++ b/ops/roles/reservations/tasks/app.yml
@@ -162,10 +162,10 @@
                   - containerPort: 8080
                 resources:
                   requests:
-                    cpu: "500m"
+                    cpu: "150m"
                     memory: "1Gi"
                   limits:
-                    cpu: "1"
+                    cpu: "300m"
                     memory: "1Gi"
                 envFrom:
                   - configMapRef:


### PR DESCRIPTION
Since OpenShift licenses are based on CPU usage, we need to set appropriate values. 
These values are based on the metrics from the last two weeks.